### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,7 +131,7 @@ As `xal`'s author, I can't do it alone. If you'd like to help:
 Ressources
 **********
 
-* Documentation: https://xal.readthedocs.org
+* Documentation: https://xal.readthedocs.io
 * PyPI: https://pypi.python.org/pypi/xal
 * Code repository: https://github.com/benoitbryon/xal
 * Bugtracker: https://github.com/benoitbryon/xal/issues

--- a/docs/presentations/2013-europython/index.txt
+++ b/docs/presentations/2013-europython/index.txt
@@ -201,7 +201,7 @@ Challenges
 xal is a proof of concept
 *************************
 
-https://xal.readthedocs.org
+https://xal.readthedocs.io
 
 
 ****************

--- a/docs/presentations/2013-europython/poster.svg
+++ b/docs/presentations/2013-europython/poster.svg
@@ -6807,7 +6807,7 @@
              sodipodi:role="line"
              id="tspan7712"
              x="3098.2415"
-             y="293.18478">https://xal.readthedocs.org</tspan></text>
+             y="293.18478">https://xal.readthedocs.io</tspan></text>
         <text
            xml:space="preserve"
            style="font-size:96px;font-style:normal;font-variant:normal;font-weight:200;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Ultra-Light"

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ VERSION = open(os.path.join(here, 'VERSION')).read().strip()
 AUTHOR = u'Benoît Bryon'
 EMAIL = 'benoit@marmelune.net'
 LICENSE = 'BSD'
-URL = 'https://{name}.readthedocs.org/'.format(name=NAME)
+URL = 'https://{name}.readthedocs.io/'.format(name=NAME)
 CLASSIFIERS = [
     'Development Status :: 1 - Planning',
     'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
